### PR TITLE
Propagate validation error details

### DIFF
--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/BaseHandlerStd.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/BaseHandlerStd.java
@@ -1,34 +1,62 @@
 package software.amazon.events.apidestination;
 
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.LimitExceededException;
+import software.amazon.awssdk.services.eventbridge.model.ResourceAlreadyExistsException;
+import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
+import software.amazon.cloudformation.exceptions.*;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.function.Supplier;
+
 // Placeholder for the functionality that could be shared across Create/Read/Update/Delete/List Handlers
 
 public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
-  @Override
-  public final ProgressEvent<ResourceModel,CallbackContext> handleRequest(
-          final AmazonWebServicesClientProxy proxy,
-          final ResourceHandlerRequest<software.amazon.events.apidestination.ResourceModel> request,
-          final software.amazon.events.apidestination.CallbackContext callbackContext,
-          final Logger logger) {
-    return handleRequest(
-            proxy,
-            request,
-            callbackContext != null ? callbackContext : new software.amazon.events.apidestination.CallbackContext(),
-            proxy.newProxy(ClientBuilder::getClient),
-            logger
-    );
-  }
 
-  protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
-          final AmazonWebServicesClientProxy proxy,
-          final ResourceHandlerRequest<ResourceModel> request,
-          final CallbackContext callbackContext,
-          final ProxyClient<EventBridgeClient> proxyClient,
-          final Logger logger);
+    public static final String VALIDATION_ERROR_CODE = "ValidationException";
+
+    @Override
+    public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<software.amazon.events.apidestination.ResourceModel> request,
+            final software.amazon.events.apidestination.CallbackContext callbackContext,
+            final Logger logger) {
+        return handleRequest(
+                proxy,
+                request,
+                callbackContext != null ? callbackContext : new software.amazon.events.apidestination.CallbackContext(),
+                proxy.newProxy(ClientBuilder::getClient),
+                logger
+        );
+    }
+
+    protected abstract ProgressEvent<ResourceModel, CallbackContext> handleRequest(
+            final AmazonWebServicesClientProxy proxy,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final CallbackContext callbackContext,
+            final ProxyClient<EventBridgeClient> proxyClient,
+            final Logger logger);
+
+    protected <T> T translateAwsServiceException(Supplier<T> supplier, String operation) {
+        try {
+            return supplier.get();
+        } catch (final ResourceAlreadyExistsException e) {
+            throw new CfnAlreadyExistsException(e);
+        } catch (final ResourceNotFoundException e) {
+            throw new CfnNotFoundException(e);
+        } catch (final LimitExceededException e) {
+            throw new CfnServiceLimitExceededException(ResourceModel.TYPE_NAME, operation, e);
+        } catch (final AwsServiceException e) {
+            if (e.awsErrorDetails() != null && VALIDATION_ERROR_CODE.equals(e.awsErrorDetails().errorCode())) {
+                throw new CfnInvalidRequestException(e.awsErrorDetails().errorMessage(), e);
+            }
+            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
+        }
+    }
+
 }

--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/BaseHandlerStd.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/BaseHandlerStd.java
@@ -2,6 +2,7 @@ package software.amazon.events.apidestination;
 
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.ConcurrentModificationException;
 import software.amazon.awssdk.services.eventbridge.model.LimitExceededException;
 import software.amazon.awssdk.services.eventbridge.model.ResourceAlreadyExistsException;
 import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
@@ -42,11 +43,13 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             final ProxyClient<EventBridgeClient> proxyClient,
             final Logger logger);
 
-    protected <T> T translateAwsServiceException(Supplier<T> supplier, String operation) {
+    protected <T> T translateAwsServiceException(String operation, Supplier<T> supplier) {
         try {
             return supplier.get();
         } catch (final ResourceAlreadyExistsException e) {
             throw new CfnAlreadyExistsException(e);
+        } catch (final ConcurrentModificationException e) {
+            throw new CfnResourceConflictException(e);
         } catch (final ResourceNotFoundException e) {
             throw new CfnNotFoundException(e);
         } catch (final LimitExceededException e) {

--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/CreateHandler.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/CreateHandler.java
@@ -1,18 +1,10 @@
 package software.amazon.events.apidestination;
 
 import com.amazonaws.util.StringUtils;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.CreateApiDestinationRequest;
 import software.amazon.awssdk.services.eventbridge.model.CreateApiDestinationResponse;
-import software.amazon.awssdk.services.eventbridge.model.LimitExceededException;
-import software.amazon.awssdk.services.eventbridge.model.ResourceAlreadyExistsException;
-import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnServiceLimitExceededException;
+import software.amazon.cloudformation.exceptions.*;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
@@ -66,23 +58,10 @@ public class CreateHandler extends BaseHandlerStd {
 
     private CreateApiDestinationResponse createResource(CreateApiDestinationRequest awsRequest, ProxyClient<EventBridgeClient> proxyClient) {
         CreateApiDestinationResponse awsResponse;
-        try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::createApiDestination);
-        } catch (final ResourceAlreadyExistsException e) {
-            // ApiDestination with the same name already exist in the customer account
-            throw new CfnAlreadyExistsException(e);
-        } catch (final ResourceNotFoundException e) {
-            // Provided connection arn does not exist
-            throw new CfnNotFoundException(e);
-        } catch (final LimitExceededException e) {
-            // Resource limit exceeded
-            throw new CfnServiceLimitExceededException(ResourceModel.TYPE_NAME, awsRequest.name(), e);
-        } catch (final AwsServiceException e) {
-            // general exception
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
-        }
 
+        awsResponse = translateAwsServiceException(() -> proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::createApiDestination), awsRequest.name());
         logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
+
         return awsResponse;
     }
 

--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/CreateHandler.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/CreateHandler.java
@@ -59,7 +59,9 @@ public class CreateHandler extends BaseHandlerStd {
     private CreateApiDestinationResponse createResource(CreateApiDestinationRequest awsRequest, ProxyClient<EventBridgeClient> proxyClient) {
         CreateApiDestinationResponse awsResponse;
 
-        awsResponse = translateAwsServiceException(() -> proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::createApiDestination), awsRequest.name());
+        awsResponse = translateAwsServiceException(awsRequest.name(),
+                () -> proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::createApiDestination)
+        );
         logger.log(String.format("%s successfully created.", ResourceModel.TYPE_NAME));
 
         return awsResponse;

--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/DeleteHandler.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/DeleteHandler.java
@@ -1,18 +1,9 @@
 package software.amazon.events.apidestination;
 
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.DeleteApiDestinationRequest;
 import software.amazon.awssdk.services.eventbridge.model.DeleteApiDestinationResponse;
-import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-
+import software.amazon.cloudformation.proxy.*;
 
 public class DeleteHandler extends BaseHandlerStd {
     private Logger logger;
@@ -48,18 +39,13 @@ public class DeleteHandler extends BaseHandlerStd {
 
     private DeleteApiDestinationResponse deleteResource(DeleteApiDestinationRequest awsRequest, ProxyClient<EventBridgeClient> proxyClient) {
         DeleteApiDestinationResponse awsResponse;
-        try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::deleteApiDestination);
-        } catch (final ResourceNotFoundException e) {
-            // Api destination does not exist
-            throw new CfnNotFoundException(e);
-        } catch (final AwsServiceException e) {
-            throw new CfnGeneralServiceException(ResourceModel.TYPE_NAME, e);
-        }
 
+        awsResponse = translateAwsServiceException(awsRequest.name(),
+                () -> proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::deleteApiDestination)
+        );
         logger.log(String.format("%s successfully deleted.", ResourceModel.TYPE_NAME));
-        return awsResponse;
 
+        return awsResponse;
     }
 
 }

--- a/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/ReadHandler.java
+++ b/aws-events-apidestination/src/main/java/software/amazon/events/apidestination/ReadHandler.java
@@ -1,17 +1,9 @@
 package software.amazon.events.apidestination;
 
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
 import software.amazon.awssdk.services.eventbridge.model.DescribeApiDestinationRequest;
 import software.amazon.awssdk.services.eventbridge.model.DescribeApiDestinationResponse;
-import software.amazon.awssdk.services.eventbridge.model.ResourceNotFoundException;
-import software.amazon.cloudformation.exceptions.CfnGeneralServiceException;
-import software.amazon.cloudformation.exceptions.CfnNotFoundException;
-import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
-import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
-import software.amazon.cloudformation.proxy.ProxyClient;
-import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
+import software.amazon.cloudformation.proxy.*;
 
 public class ReadHandler extends BaseHandlerStd {
     private Logger logger;
@@ -42,14 +34,12 @@ public class ReadHandler extends BaseHandlerStd {
 
     private DescribeApiDestinationResponse readResource(DescribeApiDestinationRequest awsRequest, ProxyClient<EventBridgeClient> proxyClient) {
         DescribeApiDestinationResponse awsResponse;
-        try {
-            awsResponse = proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeApiDestination);
-        } catch (final ResourceNotFoundException e) {
-            throw new CfnNotFoundException(ResourceModel.TYPE_NAME, awsRequest.name(), e);
-        } catch (final AwsServiceException e) {
-            throw new CfnGeneralServiceException(software.amazon.events.apidestination.ResourceModel.TYPE_NAME, e);
-        }
+
+        awsResponse = translateAwsServiceException(awsRequest.name(),
+                () -> proxyClient.injectCredentialsAndInvokeV2(awsRequest, proxyClient.client()::describeApiDestination)
+        );
         logger.log(String.format("%s has successfully been read.", ResourceModel.TYPE_NAME));
+
         return awsResponse;
     }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-events/issues/26

*Description of changes:*

Generic AWS SDK exceptions may contain validation errors that contain useful customer context about why a certain resource operation might have failed. With this commit, we propagate these errors back to CloudFormation as a CfnInvalidRequestException.

The principal objective of this request is to surface EventBridge validation error messages to CloudFormation, which should only affect the create/update operations in particular.

This is just a preliminary proposal. I've loosely modeled the exception handling on how this is done in the [KMS resource provider](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-kms/blob/master/common/src/main/java/software/amazon/kms/common/AbstractKmsApiHelper.java#L47-L83). If you like the approach, I can factor out the translation into a shared Maven module and extend it for the Connection provider as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
